### PR TITLE
🛠️  CI: remove tests action on push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: Test
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
# What does this PR do and why? 🤔

**Context:**  
The tests Github Workflow runs on every commit push. We don't need that, we only need it to run on pull requests.

**Approach:**  
Remove `push` from workflow triggers

# Testing 🧪

**How it was tested:**  
None

# Related PRs 🔗 (Optional)

None
